### PR TITLE
add configuration for the evlis version to use

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ following in your Makefile:
 ```make
 BUILD_DEPS = elvis_mk
 
-dep_elvis_mk = git https://github.com/inaka/elvis.mk.git c3bb3f5
+dep_elvis_mk = git https://github.com/inaka/elvis.mk.git 784e41b
 
 DEP_PLUGINS = elvis_mk
 ```

--- a/plugins.mk
+++ b/plugins.mk
@@ -4,14 +4,14 @@
 .PHONY: elvis distclean-elvis
 
 # Configuration.
-
+ELVIS_VERSION=0.2.6
 ELVIS_CONFIG ?= $(CURDIR)/elvis.config
 
 ELVIS ?= $(CURDIR)/elvis
 export ELVIS
 
-ELVIS_URL ?= https://github.com/inaka/elvis/releases/download/0.2.5/elvis
-ELVIS_CONFIG_URL ?= https://github.com/inaka/elvis/releases/download/0.2.5/elvis.config
+ELVIS_URL ?= https://github.com/inaka/elvis/releases/download/$(ELVIS_VERSION)/elvis
+ELVIS_CONFIG_URL ?= https://github.com/inaka/elvis/releases/download/$(ELVIS_VERSION)/elvis.config
 ELVIS_OPTS ?=
 
 # Core targets.


### PR DESCRIPTION
so there is only one place to change once the builds are online for e.g. 0.2.11
