### PR TITLE
Make the Elvis version configurable

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,9 @@
 # Change Log
+## [1.1.0](https://github.com/inaka/elvis.mk/tree/1.1.0) (2022-08-05)
+**Implemented enhancements:**
+
+- Make the Elvis version configurable [\#14](https://github.com/inaka/elvis.mk/issues/14)
+- download the source code and compile Elvis (as upstream no longer provides an executable)
 
 ## [1.0.0](https://github.com/inaka/elvis.mk/tree/1.0.0) (2016-04-12)
 **Implemented enhancements:**

--- a/README.md
+++ b/README.md
@@ -16,7 +16,13 @@ following in your Makefile:
 ```make
 BUILD_DEPS = elvis_mk
 
-dep_elvis_mk = git https://github.com/inaka/elvis.mk.git 1.0.0
+# defaults to 1.1.0
+# the version must be a tag in the repo
+# that Elvis version must compile with the installed Erlang / OTP
+# don't forget to do `make distclean` after changing the version
+# ELVIS_VERSION = 1.0.1 # downgrade
+
+dep_elvis_mk = git https://github.com/inaka/elvis.mk.git 1.1.0
 
 DEP_PLUGINS = elvis_mk
 ```

--- a/plugins.mk
+++ b/plugins.mk
@@ -4,15 +4,16 @@
 .PHONY: elvis distclean-elvis
 
 # Configuration.
-ELVIS_VERSION=0.2.11
+ELVIS_VERSION ?= 1.1.0
 ELVIS_CONFIG ?= $(CURDIR)/elvis.config
 
 ELVIS ?= $(CURDIR)/elvis
 export ELVIS
 
-ELVIS_URL ?= https://github.com/inaka/elvis/releases/download/$(ELVIS_VERSION)/elvis
-ELVIS_CONFIG_URL ?= https://github.com/inaka/elvis/releases/download/$(ELVIS_VERSION)/elvis.config
+ELVIS_URL ?= https://github.com/inaka/elvis/archive/refs/tags/$(ELVIS_VERSION).tar.gz
 ELVIS_OPTS ?=
+ELVIS_BUILD_DIR ?= $(CURDIR)/_build
+ELVIS_CODE_ARCHIVE = $(ELVIS_VERSION).tar.gz
 
 # Core targets.
 
@@ -26,13 +27,18 @@ distclean:: distclean-elvis
 # Plugin-specific targets.
 
 $(ELVIS):
-	$(gen_verbose) $(call core_http_get,$(ELVIS),$(ELVIS_URL))
+	$(gen_verbose) mkdir -p $(ELVIS_BUILD_DIR)
+	$(gen_verbose) $(call core_http_get,$(ELVIS_BUILD_DIR)/$(ELVIS_CODE_ARCHIVE),$(ELVIS_URL))
+	$(gen_verbose) cd $(ELVIS_BUILD_DIR) && \
+		tar -xzf $(ELVIS_CODE_ARCHIVE) && \
+		cd elvis-$(ELVIS_VERSION) && \
+		rebar3 escriptize
+	$(gen_verbose) cp $(ELVIS_BUILD_DIR)/elvis-$(ELVIS_VERSION)/_build/default/bin/elvis $(ELVIS)
+	$(gen_verbose) cp --no-clobber $(ELVIS_BUILD_DIR)/elvis-$(ELVIS_VERSION)/elvis.config $(ELVIS_CONFIG)
 	$(verbose) chmod +x $(ELVIS)
+	$(gen_verbose) rm -rf $(ELVIS_BUILD_DIR)
 
-$(ELVIS_CONFIG):
-	$(verbose) $(call core_http_get,$(ELVIS_CONFIG),$(ELVIS_CONFIG_URL))
-
-elvis: $(ELVIS) $(ELVIS_CONFIG)
+elvis: $(ELVIS)
 	$(verbose) $(ELVIS) rock -c $(ELVIS_CONFIG) $(ELVIS_OPTS)
 
 distclean-elvis:


### PR DESCRIPTION
- just add `ELVIS_VERSION = <major.minor.revision>` to your Makefile
- had to change the way Elvis is pulled in
  - pull the tar.gz archive from Github
  - unarchive
  - build with rebar3
  - this means there will no longer be compatibility issues because of the Erlang / OTP version
  - but might be brittle because it relies on the rebar3 command being available ...