### PR TITLE
Allow recent changes to be used in OTP24

### DIFF
--- a/plugins.mk
+++ b/plugins.mk
@@ -4,7 +4,7 @@
 .PHONY: elvis distclean-elvis
 
 # Configuration.
-ELVIS_VERSION ?= 4.0.0
+ELVIS_VERSION ?= 4.0.0-otp24
 ELVIS_CONFIG ?= $(CURDIR)/elvis.config
 
 ELVIS ?= $(CURDIR)/elvis


### PR DESCRIPTION
Using the versions from https://github.com/inaka/elvis/pull/593 and https://github.com/inaka/elvis_core/pull/400